### PR TITLE
Mail Patcher URL Updated

### DIFF
--- a/_pages/stats.html
+++ b/_pages/stats.html
@@ -44,7 +44,7 @@ permalink: /status/
     <tr>
         <td>Mail</td>
         <td><div class="status-beta"></div></td>
-        <td>This service is currently in the public beta. Visit the <a href="https://mail.disconnect24.xyz/">patching site</a> to learn more.</td>
+        <td>This service is currently in the public beta. Visit the <a href="https://mail.service.dc24.xyz/">patching site</a> to learn more.</td>
     </tr>
     <tr>
         <td>Check Mii Out Channel</td>


### PR DESCRIPTION
Added new Mail Patcher URL (mail.service.dc24.xyz) rather than old domain (mail.disconnect24.xyz)