### PR TITLE
DC24 channel forwarder suggestion added

### DIFF
--- a/_pages/stats.html
+++ b/_pages/stats.html
@@ -57,6 +57,11 @@ permalink: /status/
         <td>(Currently only a Mail Patcher) The Disconnect24 Channel is available <a href="https://github.com/Disconnect24/dc24-channel">here</a>.</td>
     </tr>
     <tr>
+        <td>Disconnect24 Channel Forwarder</td>
+        <td><div class="status-not-considering"></div></td>
+        <td>This project is being currently being worked on, however it is not officially supported under DC24. This will be merged with <a href="https://github.com/Disconnect24/dc24-channel">this</a> once it is completed and approved.</td>
+    </tr>
+    <tr>
         <td>Nintendo Channel</td>
         <td><div class="status-in-progress"></div></td>
         <td>Almost ready! We're currently doing some decoding and mods for the keys.</td>


### PR DESCRIPTION
Its under its own tab since it is not officially supported, however if its complete it will be removed and merged with the DC24 channel status tab.